### PR TITLE
画面に反映する実績を3つに増加

### DIFF
--- a/containers/user/debug/debug.http
+++ b/containers/user/debug/debug.http
@@ -13,7 +13,9 @@ Content-Type: application/json
 
 {
   "name": "テスト太郎2",
-  "record_id": "記録2",
+  "display_achive_id1": "achive-d3c9d4be-84c2-5b4d-b116-088a8c8680a5",
+  "display_achive_id2": "achive-86548e0a-41ab-9617-c248-094e2de7f4f5",
+  "display_achive_id3": "achive-46e37298-1052-a002-4cc4-1567df59bae5",
   "comment": "これはテスト用のコメントです。",
   "region_id": "北海道",
   "system_game_id": "",
@@ -27,11 +29,13 @@ Content-Type: application/json
 
 {
   "name": "テスト太郎",
-  "record_id": "記録2",
-  "comment": "これはテスト用のコメントです。",
-  "system_game_id": "f5b632cb-707d-f450-eece-f119534b724a",
-  "admin_game_id": "01e32526-1c27-c9a9-2b5b-d158b0f50c80"
+  "comment": "これはテスト用のコメントです。3",
+  "system_game_id": "systemgame-f5b632cb-707d-f450-eece-f119534b724a",
+  "admin_game_id": "admingame-01e32526-1c27-c9a9-2b5b-d158b0f50c80"
 }
+
+### 実績取得
+GET {{{{base_url}}}}/
 
 ### プライバシー取得
 GET  {{base_url}}/privacy
@@ -62,4 +66,20 @@ Userid: {{user_id}}
 
 {
   "region_id": "関西地方"
+}
+
+### 実績の取得
+GET {{base_url}}/achive
+Content-Type: application/json
+Userid: {{user_id}}
+
+### 実績の編集
+PUT {{base_url}}/achive
+Content-Type: application/json
+Userid: {{user_id}}
+
+{
+  "display_achive_id1": "9d89644f-a0aa-e270-9c2b-2c0a88c85a93",
+  "display_achive_id2": "9d5e7f55-eb7b-c2fd-5284-9b645e34eb3a",
+  "display_achive_id3": "669ee10d-759f-584d-cd42-38af7850e41d"
 }

--- a/containers/user/src/controllers/profile_controller.go
+++ b/containers/user/src/controllers/profile_controller.go
@@ -5,20 +5,14 @@ import (
 
 	"net/http"
 	"user/services"
-
 	"github.com/labstack/echo/v4"
 	"gorm.io/gorm"
 )
 
-// updateするための構造体
-type Input struct {
-	Name     string `json:"name"`           //ユーザ名
-	RecordID string `json:"record_id"`      // 実績ID
-	Comment  string `json:"comment"`        //コメント
-	RegionID string `json:"region_id"`      // 地域ID
-	SysGame  string `json:"system_game_id"` // システムゲームID
-	AdmGame  string `json:"admin_game_id"`  // アドミンゲームID
-}
+
+/*
+	プロフィール処理
+*/
 
 // プロフィールをIDから取得
 func GetProfileById(c echo.Context) error {
@@ -40,8 +34,9 @@ func GetProfileById(c echo.Context) error {
 	return c.JSON(http.StatusOK, profile)
 }
 
+// プロフィール作成
 func CreateProfile(c echo.Context) error {
-	var req Input
+	var req services.Input
 	//リクエスト整形(bind)
 	if err := c.Bind(&req); err != nil {
 		return c.JSON(http.StatusBadRequest, echo.Map{"error": "invalid input"})
@@ -50,7 +45,6 @@ func CreateProfile(c echo.Context) error {
 	//入力したデータを格納
 	input := services.Input{
 		Name:     req.Name,
-		RecordID: req.RecordID,
 		Comment:  req.Comment,
 		RegionID: req.RegionID,
 		SysGame:  req.SysGame,
@@ -76,7 +70,7 @@ func CreateProfile(c echo.Context) error {
 func UpdateProfileById(c echo.Context) error {
 	//useridをヘッダーから取得
 	userID := c.Request().Header.Get("userid")
-	var req Input
+	var req services.Input
 
 	//リクエスト整形(bind)
 	if err := c.Bind(&req); err != nil {
@@ -86,9 +80,10 @@ func UpdateProfileById(c echo.Context) error {
 	//リクエストを格納
 	input := services.Input{
 		Name:     req.Name,
-		RecordID: req.RecordID,
 		Comment:  req.Comment,
 		RegionID: req.RegionID,
+		SysGame: req.SysGame,
+		AdmGame: req.AdmGame,
 	}
 
 	//エラー処理
@@ -103,6 +98,66 @@ func UpdateProfileById(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, echo.Map{"status": "profile updated"})
 }
+
+/*
+	実績関連処理
+*/
+
+//実績を取得する
+func GetAchiveProfile(c echo.Context) error {
+	//userIDを取得
+	UserID := c.Request().Header.Get("userid")
+
+	//service実行
+	Achivement, err := services.GetAchiveProfile(UserID)
+
+	//エラー処理
+	if err != nil {
+		//NotFoundのとき
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return c.JSON(http.StatusNotFound, echo.Map{"error": "Achivement profile not found"})
+		}
+		//NotFound以外のエラー
+		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "internal error"})
+	}
+	
+	//実績を返す
+	return c.JSON(http.StatusOK, Achivement)
+}
+
+// 実績更新
+func UpdateAchiveProfile(c echo.Context) error {
+	UserID := c.Request().Header.Get("userid")
+	var req services.AchiveInput
+
+	//リクエスト整形(bind)
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusBadRequest, echo.Map{"error": "invalid input"})
+	}
+
+	input := services.AchiveInput{
+		DisplayAchiveID1: req.DisplayAchiveID1,
+		DisplayAchiveID2: req.DisplayAchiveID2,
+		DisplayAchiveID3: req.DisplayAchiveID3,
+	}
+
+	//エラー処理
+	if err := services.UpdateAchiveProfile(UserID, input); err != nil {
+		//Notfoundのとき
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return c.JSON(http.StatusNotFound, echo.Map{"error": "privacy profile not found"})
+		}
+		//Notfound以外のエラー
+		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "update failed"})
+	}
+
+	return c.JSON(http.StatusOK, echo.Map{"status": "privacy updated!"})
+
+}
+
+/*
+	プライバシー関連
+*/
 
 // プライバシー情報を取得
 func GetPrivacyProfile(c echo.Context) error {
@@ -149,6 +204,10 @@ func UpdatePrivacyProfile(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, echo.Map{"status": "privacy updated!"})
 }
+
+/*
+	地域情報関連
+*/
 
 // 地域情報の取得
 func GetRegionProfile(c echo.Context) error {

--- a/containers/user/src/models/profile.go
+++ b/containers/user/src/models/profile.go
@@ -10,7 +10,9 @@ import (
 type Profile struct {
 	UserID    string  `gorm:"primaryKey;type:varchar(50)" json:"user_id"`        // ユーザID
 	Name      string  `gorm:"type:varchar(100);default:''" json:"name"`          //ユーザ名
-	RecordID  string  `gorm:"type:varchar(50);default''" json:"record_id"`                 // 実績ID
+	DisplayAchiveID1  string  `gorm:"type:varchar(50);default''" json:"display_achive_id1"`       // 実績ID1
+	DisplayAchiveID2  string  `gorm:"type:varchar(50);default''" json:"display_achive_id2"`       // 実績ID2
+	DisplayAchiveID3  string  `gorm:"type:varchar(50);default''" json:"display_achive_id3"`       // 実績ID3
 	Comment   string  `gorm:"type:varchar(255);default:''" json:"comment"`       // ユーザコメント（デフォルト空白）
 	Latitude  float64 `gorm:"type:double;default:0" json:"latitude"`             // 緯度（デフォルト0）
 	Longitude float64 `gorm:"type:double;default:0" json:"longitude"`            // 経度（デフォルト0）
@@ -27,6 +29,13 @@ type PrivacyProfile struct {
 	Size      int     `json:"size"`
 }
 
+//画面に設定する実績情報のみの構造体
+type AchiveProfile struct {
+	DisplayAchiveID1  string  `json:"display_achive_id1"`       // 実績ID1
+	DisplayAchiveID2  string  `json:"display_achive_id2"`       // 実績ID2
+	DisplayAchiveID3  string  `json:"display_achive_id3"`       // 実績ID3
+}
+
 func (Profile) TableName() string {
 	return "Profile"
 }
@@ -36,12 +45,17 @@ func DebugProfile() {
 	user_id := "userid-e3abf90d-4bcf-4c3b-bbde-37694b1611b3"
 	system_game_id := "systemgame-f5b632cb-707d-f450-eece-f119534b724c"
 	admin_game_id := "admingame-01e32526-1c27-c9a9-2b5b-d158b0f50c83"
+	display_achive_ID1 := "achive-d3c9d4be-84c2-5b4d-b116-088a8c8680ab"
+	display_achive_ID2 := "achive-86548e0a-41ab-9617-c248-094e2de7f4f4"
+	display_achive_ID3 := "achive-46e37298-1052-a002-4cc4-1567df59bae4"
 
 	//書き込み
 	result := dbconn.Save(&Profile{
 		UserID:    user_id,
 		Name:      "山田太郎",
-		RecordID:  "第一回優勝",
+		DisplayAchiveID1: display_achive_ID1,
+		DisplayAchiveID2: display_achive_ID2,
+		DisplayAchiveID3: display_achive_ID3,
 		Comment:   "よろしくお願いします。",
 		Latitude:  35.23,
 		Longitude: 135.25,
@@ -74,6 +88,9 @@ func DebugProfile() {
 
 	logger.PrintErr("プロフィール取得成功")
 }
+/*
+	プロフィール全体関連
+*/
 
 // IDからプロフィールを返す
 func FindProfileById(userID string) (*Profile, error) {
@@ -138,6 +155,50 @@ func UpdateProfile(userID string, data Profile) error {
 	return nil
 }
 
+/*
+	実績関連
+*/
+
+//
+func FindAchiveProfile(userID string) (*AchiveProfile, error) {
+
+	Profile, err := FindProfileById(userID)
+
+	if err != nil {
+		logger.PrintErr("実績取得エラー")
+		return nil, err
+	}
+
+	return &AchiveProfile{
+		DisplayAchiveID1: Profile.DisplayAchiveID1,
+		DisplayAchiveID2: Profile.DisplayAchiveID2,
+		DisplayAchiveID3: Profile.DisplayAchiveID3,
+	}, nil
+}
+
+//実績情報を編集する
+func UpdateAchiveProfile(userID string, data AchiveProfile) error {
+	result := dbconn.Model(&Profile{}).Where("user_id = ?", userID).Updates(data)
+
+	//エラーを返す
+	if result.Error != nil {
+		logger.PrintErr("実績編集エラー",result.Error)
+		return result.Error
+	}
+
+	//0件エラー
+	if result.RowsAffected == 0{
+		logger.PrintErr("変更レコード0件エラー")
+		return gorm.ErrRecordNotFound
+	}
+
+	return nil
+}
+
+/*
+	プライバシー関連
+*/
+
 //プライバシー情報を返す
 func FindPrivacyProfile(userID string) (*PrivacyProfile, error) {
 	//ProfileをIDから全項目一件検索
@@ -175,6 +236,10 @@ func UpdatePrivacyProfile(userID string, data PrivacyProfile) error {
 
 	return nil
 }
+
+/*
+	地域情報関連
+*/
 
 //地域情報を返す
 func FindRegionProfile (userID string) (string, error) {

--- a/containers/user/src/routes/routes.go
+++ b/containers/user/src/routes/routes.go
@@ -25,6 +25,10 @@ func InitRoute(router *echo.Echo) *echo.Echo {
 	router.GET("/region", controllers.GetRegionProfile)
 	//所属地域の編集
 	router.PUT("/region", controllers.UpdateRegionProfile)
+	//実績の取得
+	router.GET("/achive", controllers.GetAchiveProfile)
+	//実績の編集
+	router.PUT("/achive", controllers.UpdateAchiveProfile)
 
 	return router
 }

--- a/containers/user/src/services/profile_service.go
+++ b/containers/user/src/services/profile_service.go
@@ -8,11 +8,17 @@ import (
 // 基本プロフィールの構造体
 type Input struct {
 	Name     string `json:"name"`           //ユーザ名
-	RecordID string `json:"record_id"`      // 実績ID
 	Comment  string `json:"comment"`        //コメント
 	RegionID string `json:"region_id"`      // 地域ID
 	SysGame  string `json:"system_game_id"` // システムゲームID
 	AdmGame  string `json:"admin_game_id"`  // アドミンゲームID
+}
+
+//　ユーザの実績の構造体
+type AchiveInput struct {
+	DisplayAchiveID1  *string  `json:"display_achive_id1"`       // 実績ID1
+	DisplayAchiveID2  *string  `json:"display_achive_id2"`       // 実績ID2
+	DisplayAchiveID3  *string  `json:"display_achive_id3"`       // 実績ID3
 }
 
 // プライバシー情報の構造体
@@ -21,6 +27,10 @@ type PrivacyInput struct {
 	Longitude *float64 `json:"longitude"`
 	Size      *int     `json:"size"`
 }
+
+/*
+	プロフィール全体関連
+*/
 
 // Profile情報を全て取得
 func GetProfileService(userID string) (*models.Profile, error) {
@@ -32,7 +42,6 @@ func CreateProfileService(input Input) (string, error){
 	//構造体にinputを格納
 	profile := models.Profile{
 		Name: input.Name,
-		RecordID: input.RecordID,
 		Comment:  input.Comment,
 		RegionID: input.RegionID,
 		SysGame: input.SysGame,
@@ -61,11 +70,6 @@ func UpdateProfileById(UserID string, input Input) error {
 		targetProfile.Name = input.Name
 	}
 
-	//実績IDが空文字でない時のみ代入
-	if input.RecordID != "" {
-		targetProfile.RecordID = input.RecordID
-	}
-
 	//コメントが空文字でない時のみ代入
 	if input.Comment != "" {
 		targetProfile.Comment = input.Comment
@@ -88,6 +92,53 @@ func UpdateProfileById(UserID string, input Input) error {
 
 	return models.UpdateProfile(UserID, *targetProfile)
 }
+
+/*
+	実績関連
+*/
+
+func GetAchiveProfile(userID string) (*models.AchiveProfile, error) {
+	return models.FindAchiveProfile(userID)
+}
+
+func UpdateAchiveProfile(userID string, input AchiveInput) error {
+	//UserIDが空文字ならエラー返す
+	if userID == "" {
+		return errors.New("userID is required")
+	}
+
+	//存在確認
+	AchiveProfile, err := models.FindAchiveProfile(userID)
+
+	//エラー処理
+	if err != nil {
+		return err
+	}
+
+	// 3つの実績が空文字でない時のみ代入
+	if input.DisplayAchiveID1 != nil {
+		AchiveProfile.DisplayAchiveID1 = *input.DisplayAchiveID1
+	}
+
+	if input.DisplayAchiveID2 != nil {
+		AchiveProfile.DisplayAchiveID2 = *input.DisplayAchiveID2
+	}
+
+	if input.DisplayAchiveID3 != nil {
+		AchiveProfile.DisplayAchiveID3 = *input.DisplayAchiveID3
+	}
+
+	//　実行結果を返す
+	return models.UpdateAchiveProfile(userID, models.AchiveProfile{
+		DisplayAchiveID1: AchiveProfile.DisplayAchiveID1,
+		DisplayAchiveID2: AchiveProfile.DisplayAchiveID2,
+		DisplayAchiveID3: AchiveProfile.DisplayAchiveID3,
+	})
+}
+
+/*
+	プライバシー関連
+*/
 
 // プライバシー情報の取得
 func GetPrivacyProfileService(UserID string) (*models.PrivacyProfile, error) {
@@ -130,6 +181,10 @@ func UpdatePrivacyProfileById(UserID string, input PrivacyInput) error {
 		Size:      privacyProfile.Size,
 	})
 }
+
+/*
+	地域情報関連
+*/
 
 // 所属地域の取得
 func GetRegionProfileService(UserID string) (string, error) {


### PR DESCRIPTION
実績を画面に3つ反映できるよう、テーブルを一部変更し、それにならびservice,controller,routerの実績部分を変更しました。

テスト済みです。